### PR TITLE
Blank lines fix

### DIFF
--- a/lib/drop_cap_text.dart
+++ b/lib/drop_cap_text.dart
@@ -201,6 +201,7 @@ class DropCapText extends StatelessWidget {
                 child: Container(
                   padding: EdgeInsets.only(top: indentation.dy),
                   height: (lineHeight * min(maxLines ?? rows, rows)) + indentation.dy,
+                  width: boundsWidth,
                   child: RichText(
                     overflow: (maxLines == null || (maxLines > rows && overflow == TextOverflow.fade))
                         ? TextOverflow.clip


### PR DESCRIPTION
Fixed issue with blank lines beside dropCap on Android. Explicitly setting the boundsWidth to the container resolves the problem.